### PR TITLE
clarify types for rust/pull/44287

### DIFF
--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -168,7 +168,8 @@ impl Estimate for Quantile {
                 } else {
                     self.q[i] = self.linear(i, d);
                 }
-                self.n[i] += d.approx().unwrap();  // d == +-1
+                let delta: i64 = d.approx().unwrap();  // d == +-1
+                self.n[i] += delta;
             }
         }
     }


### PR DESCRIPTION
If rust/pull/44287 lands  then [cargobomb](https://github.com/rust-lang/rust/pull/44287#issuecomment-329089956) tells us that this line will have a type ambiguity error, so this is a PR to preemptively prevent that.