### PR TITLE
update dependencies and bump MSRV

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
             toolchain: nightly
           - os: ubuntu-latest
             target: x86_64-unknown-linux-gnu
-            toolchain: 1.36.0  # MSRV
+            toolchain: 1.51.0  # MSRV
           - os: ubuntu-latest
             deps: sudo apt-get update ; sudo apt install gcc-multilib
             target: i686-unknown-linux-gnu

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,7 +37,7 @@ num-traits = { version = "0.2", default-features = false }
 float-ord = "0.3"
 easy-cast = { version = "0.4", default-features = false, optional = true }
 serde_derive = { version = "1", optional = true }
-serde-big-array = { version = "0.3.0", optional = true }
+serde-big-array = { version = "0.4", optional = true }
 rayon = { version = "1.3", optional = true }
 
 [dependencies.serde]
@@ -54,12 +54,7 @@ rand_distr = "0.4"
 serde_json = "1"
 streaming-stats = "0.2"
 quantiles = "0.7"
-# Proptest 1.0 has a higher MSRV than we do
-proptest = "0.10"
-# The following are not direct dependencies, but the recent versions have a too
-# high MSRV:
-byteorder = "=1.3"
-bitflags = "=1.2"
+proptest = "1"
 
 [package.metadata.docs.rs]
 # Enable certain features when building docs for docs.rs

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The following features are available:
 
 ## Rust version requirements
 
-Rustc version 1.36 or greater is supported.
+Rustc version 1.51 or greater is supported.
 
 
 ## Related Projects


### PR DESCRIPTION
The current MSRV of 1.36 is increasingly outdated, as are some of the dependencies. This PR updates all dependencies to the latest available versions, and bumps the documented MSRV to 1.51 (which is now ~18 months old):

- serde-big-array 0.4: MSRV 1.51
- proptest 1: MSRV 1.50
- byteorder 1.4.x: MSRV 1.41.1
- bitflags 1.3.x: MSRV 1.46

All linux distributions that I checked should work with Rust 1.51 - except maybe debian stable, which has both Rust 1.48 and 1.51 available.