### PR TITLE
Fix compile error when running benches without default features

### DIFF
--- a/benches/kurtosis.rs
+++ b/benches/kurtosis.rs
@@ -16,6 +16,7 @@ fn initialize_vec() -> Vec<f64> {
     values
 }
 
+#[cfg(feature = "libm")]
 fn bench_kurtosis(b: &mut Bencher) {
     let values = initialize_vec();
     b.iter(|| {
@@ -32,5 +33,9 @@ fn bench_moments(b: &mut Bencher) {
     });
 }
 
+#[cfg(feature = "libm")]
 benchmark_group!(benches, bench_kurtosis, bench_moments);
+#[cfg(not(feature = "libm"))]
+benchmark_group!(benches, bench_moments);
+
 benchmark_main!(benches);


### PR DESCRIPTION
Add config option so that the benches can be executed with the various features turned on or off.

Without this I get this error:

```
[capitol@batia average]$ cargo bench --no-default-features
   Compiling average v0.13.1 (/home/capitol/project/average)
error[E0412]: cannot find type `Kurtosis` in crate `average`
  --> benches/kurtosis.rs:22:25
   |
22 |         let m: average::Kurtosis = values.iter().copied().collect();
   |                         ^^^^^^^^ not found in `average`

For more information about this error, try `rustc --explain E0412`.
error: could not compile `average` due to previous error
warning: build failed, waiting for other jobs to finish...
```

This is needed when packaging the crate for debian, due to the debian testsuite testing all the different features individually.