### PR TITLE
the test quantile::reference is broken on i686

### DIFF
--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -214,5 +214,5 @@ fn reference() {
     assert_eq!(q.n, [1, 6, 10, 16, 20]);
     assert_eq!(q.m, [1., 5.75, 10.50, 15.25, 20.0]);
     assert_eq!(q.len(), 20);
-    assert_almost_eq!(q.quantile(), 4.2462394088036435, 0.000000000000002);
+    assert_almost_eq!(q.quantile(), 4.2462394088036435, 2e-15);
 }

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -199,7 +199,6 @@ impl Estimate for Quantile {
     }
 }
 
-#[cfg(not(target_arch = "i686"))]
 #[test]
 fn reference() {
     let observations = [
@@ -215,5 +214,5 @@ fn reference() {
     assert_eq!(q.n, [1, 6, 10, 16, 20]);
     assert_eq!(q.m, [1., 5.75, 10.50, 15.25, 20.0]);
     assert_eq!(q.len(), 20);
-    assert_eq!(q.quantile(), 4.2462394088036435);
+    assert_almost_eq!(q.quantile(), 4.2462394088036435, 0.000000000000002);
 }

--- a/src/quantile.rs
+++ b/src/quantile.rs
@@ -199,6 +199,7 @@ impl Estimate for Quantile {
     }
 }
 
+#[cfg(not(target_arch = "i686"))]
 #[test]
 fn reference() {
     let observations = [


### PR DESCRIPTION
Fixed by adding a cfg flag to not run it on i686.
```
Full test output:
---- quantile::reference stdout ----
thread 'quantile::reference' panicked at 'assertion failed: `(left == right)`
  left: `4.246239408803645`,
 right: `4.2462394088036435`', src/quantile.rs:217:5
stack backtrace:
   0: rust_begin_unwind
             at /usr/src/rustc-1.59.0/library/std/src/panicking.rs:498:5
   1: core::panicking::panic_fmt
             at /usr/src/rustc-1.59.0/library/core/src/panicking.rs:116:14
   2: core::panicking::assert_failed_inner
   3: core::panicking::assert_failed
             at /usr/src/rustc-1.59.0/library/core/src/panicking.rs:154:5
   4: average::quantile::reference
             at ./src/quantile.rs:217:5
   5: average::quantile::reference::{{closure}}
             at ./src/quantile.rs:203:1
   6: core::ops::function::FnOnce::call_once
             at /usr/src/rustc-1.59.0/library/core/src/ops/function.rs:227:5
   7: core::ops::function::FnOnce::call_once
             at /usr/src/rustc-1.59.0/library/core/src/ops/function.rs:227:5
note: Some details are omitted, run with `RUST_BACKTRACE=full` for a verbose backtrace.
```