### PR TITLE
Support visibility to concatenate macro

### DIFF
--- a/src/macros.rs
+++ b/src/macros.rs
@@ -90,11 +90,11 @@ macro_rules! assert_almost_eq {
 /// ```
 #[macro_export]
 macro_rules! concatenate {
-    ( $name:ident, $([$estimator:ident, $statistic:ident]),+ ) => {
-        concatenate!( $name, $([$estimator, $statistic, $statistic]),* );
+    ( $visibility:vis $name:ident, $([$estimator:ident, $statistic:ident]),+ ) => {
+        concatenate!($visibility $name, $([$estimator, $statistic, $statistic]),* );
     };
-    ( $name:ident, $( [$estimator:ident, $field:ident, $($statistic:ident),+] ),+ ) => {
-        struct $name {
+    ( $visibility:vis $name:ident, $( [$estimator:ident, $field:ident, $($statistic:ident),+] ),+ ) => {
+        $visibility struct $name {
         $(
             $field: $estimator,
         )*

--- a/tests/integration/macros.rs
+++ b/tests/integration/macros.rs
@@ -2,7 +2,7 @@
 
 use average::{concatenate, Estimate, Max, Min};
 
-concatenate!(MinMax, [Min, min], [Max, max]);
+concatenate!(pub MinMax, [Min, min], [Max, max]);
 
 #[test]
 fn concatenate_simple() {

--- a/tests/integration/main.rs
+++ b/tests/integration/main.rs
@@ -21,3 +21,7 @@ mod skewness;
 mod streaming_stats;
 mod weighted_mean;
 mod covariance;
+
+// Ensure that the struct defined by macro is accessible
+#[allow(unused_imports)]
+use macros::MinMax;


### PR DESCRIPTION
Fix #19 
Hi, thanks for building such an amazing crate!

I also want to `concatenate!` can be expanded to pub `struct`.
And I've realized that it can be done by small changes.